### PR TITLE
Make output file (search.md) read-only

### DIFF
--- a/abc.txt
+++ b/abc.txt
@@ -1,0 +1,1 @@
+TODO: Inform roger about the state of the project

--- a/docker/windows-cross-compile/Dockerfile
+++ b/docker/windows-cross-compile/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:latest
+
+RUN apt update && apt upgrade -y
+RUN apt install -y g++-mingw-w64-x86-64
+
+RUN rustup target add x86_64-pc-windows-gnu
+RUN rustup toolchain install stable-x86_64-pc-windows-gnu
+
+WORKDIR /app
+
+COPY . .
+
+CMD cargo build --target x86_64-pc-windows-gnu --release

--- a/justfile
+++ b/justfile
@@ -1,0 +1,3 @@
+build-win:
+    docker build docker/windows-cross-compile/ -t rust_cross_compile/windows
+    docker run --rm -v $(pwd):/app rust_cross_compile/windows

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -28,13 +28,16 @@ where
 
     let results = search(
         sections,
-        config.search_terms,
-        config.search_mode,
+        config.search_terms.clone(),
+        config.search_mode.clone(),
         config.from,
         config.until,
     );
 
-    let output_string = search_results_to_string(results, config.ordering);
+    let search_result_string = search_results_to_string(results, config.ordering.clone());
+    let search_summary = search_summary(config.clone());
+    let output_string = format!("{}\n\n{}", search_result_string, search_summary);
+
     for writer in writers {
         writer.write_output(&output_string)?;
     }
@@ -134,6 +137,35 @@ fn search_results_to_string(
     }
 
     section_strings.join("\n\n---\n\n")
+}
+
+fn search_summary(config: SearchConfig) -> String {
+    let tags = config.search_terms.iter().map(|t| t.inner()).collect::<Vec<_>>().join(", ");
+    let mode = match config.search_mode {
+        TagSearchMode::Or => "OR",
+        TagSearchMode::And => "AND",
+    };
+    let from = match config.from {
+        Some(d) => d.to_string(),
+        None => String::new(),
+    };
+    let until = match config.until {
+        Some(d) => d.to_string(),
+        None => "".to_string(),
+    };
+    let ordering = match config.ordering {
+        SectionOrderingCriterion::Date => "date",
+        SectionOrderingCriterion::Relevance => "relevance",
+    };
+
+    format!(
+        "SEARCHED FOR TAGS: {}\nMODE: {}\nFROM: {}\nTO: {}\nORDERING: {}\n",
+        tags,
+        mode,
+        from,
+        until,
+        ordering,
+    )
 }
 
 fn ordered_search_result_sections(

--- a/src/models/errors.rs
+++ b/src/models/errors.rs
@@ -6,6 +6,7 @@ pub enum MDPError {
     MDPSyntaxError(String),
     IOReadError(PathBuf),
     IOWriteError(PathBuf),
+    IOError(String),
     ConfigError(ConfigError),
 
     MultiError(Vec<MDPError>),
@@ -28,6 +29,7 @@ impl Display for MDPError {
                 Some(ff) => format!("An error occured while writing the following file: {}", ff),
                 None => "An error occured while writing a file".to_string(),
             },
+            Self::IOError(s) => s.to_string(),
             Self::ConfigError(e) => e.to_string(),
             Self::MultiError(errors) => format!(
                 "Multiple errors occured:\n{}",


### PR DESCRIPTION
Now the output file of the `search` command is read only. Additionally, to make it even more clear (and to help interpret old output files) a footer is written to every output file. The footer contains information about the search that was performed.

Resolves issue 1.